### PR TITLE
fix: prevent blocking by running Loki client handle in goroutine

### DIFF
--- a/handler.go
+++ b/handler.go
@@ -69,7 +69,11 @@ func (h *LokiHandler) Handle(ctx context.Context, record slog.Record) error {
 	fromContext := slogcommon.ContextExtractor(ctx, h.option.AttrFromContext)
 	attrs := h.option.Converter(h.option.AddSource, h.option.ReplaceAttr, append(h.attrs, fromContext...), h.groups, &record)
 
-	return h.option.Client.Handle(attrs, record.Time, record.Message)
+	go func() {
+		_ = h.option.Client.Handle(attrs, record.Time, record.Message)
+	}()
+
+	return nil
 }
 
 func (h *LokiHandler) WithAttrs(attrs []slog.Attr) slog.Handler {


### PR DESCRIPTION
- When calling Client.Handle, the log entry is written to an unbuffered channel. This write blocks when the Loki client is trying to send a log batch to the Loki server. When the Loki server is unreachable, this can block for multiple minutes.
- This change fixes the issue by running Client.Handle in a separate goroutine.

Fixes #18